### PR TITLE
fix missing user string desc in MSC and CustomHID

### DIFF
--- a/Class/CustomHID/Src/usbd_customhid.c
+++ b/Class/CustomHID/Src/usbd_customhid.c
@@ -128,6 +128,9 @@ USBD_ClassTypeDef  USBD_CUSTOM_HID =
   USBD_CUSTOM_HID_GetOtherSpeedCfgDesc,
   USBD_CUSTOM_HID_GetDeviceQualifierDesc,
 #endif /* USE_USBD_COMPOSITE  */
+#if (USBD_SUPPORT_USER_STRING_DESC == 1U)
+  NULL,
+#endif
 };
 
 #ifndef USE_USBD_COMPOSITE

--- a/Class/MSC/Src/usbd_msc.c
+++ b/Class/MSC/Src/usbd_msc.c
@@ -125,6 +125,9 @@ USBD_ClassTypeDef  USBD_MSC =
   USBD_MSC_GetOtherSpeedCfgDesc,
   USBD_MSC_GetDeviceQualifierDescriptor,
 #endif /* USE_USBD_COMPOSITE */
+#if (USBD_SUPPORT_USER_STRING_DESC == 1U)
+  NULL,
+#endif
 };
 
 /* USB Mass storage device Configuration Descriptor */


### PR DESCRIPTION
Fix missing user string descriptor getters in MSC and CustomHID `USBD_ClassTypeDef`